### PR TITLE
Refactor todos: improve toggle logic, DRY code, error handling, and styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -997,6 +999,7 @@ name = "todo"
 version = "0.1.0"
 dependencies = [
  "gloo-storage 0.3.0",
+ "gloo-timers 0.3.0",
  "serde",
  "uuid",
  "wasm-bindgen-test",
@@ -1086,6 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
-name = "todo"
+name = "todo" 
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
-web-sys = { version = "0.3", features = ["HtmlInputElement"] }
-gloo-storage = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-uuid = { version = "1.10", features = ["v4"] }
+gloo-storage = "0.3"
+uuid = { version = "1.3", features = ["v4", "serde"] }
+web-sys = { version = "0.3", features = ["HtmlInputElement", "Event", "FocusEvent"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
- [x] DRY up repeated logic with `update_todos` helper
- [x] Fix `toggle_todo` logic
- [x] Use map instead of clone in `update_todo_title`
- [x] Handle potential panic in `focus_input`
- [x] Add constants for button classes
- [x] Add error handling for local storage